### PR TITLE
Enable Ensure Extensions to return true if the collection was modified

### DIFF
--- a/Runtime/Extensions/ArrayExtensions.cs
+++ b/Runtime/Extensions/ArrayExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace RealityCollective.Extensions
 {
@@ -83,7 +84,7 @@ namespace RealityCollective.Extensions
         /// <typeparam name="T">The type of data contained with the array</typeparam>
         /// <param name="array">The Array of items to search</param>
         /// <param name="item">The item to search for in the array</param>
-        /// <returns></returns>
+        /// <returns>True if the array contains the supplied item</returns>
         public static bool Contains<T>(this T[] array, T item) where T : IComparable<T>
         {
             if (array == null || array.Length == 0)
@@ -102,6 +103,25 @@ namespace RealityCollective.Extensions
             }
 
             return isFound;
+        }
+
+        /// <summary>
+        /// Validate if an array contains an <see cref="IComparable"/> Item
+        /// </summary>
+        /// <typeparam name="T">The type of data contained with the array</typeparam>
+        /// <param name="array">The Array of items to search</param>
+        /// <param name="item">The item to search for in the array</param>
+        /// <param name="returnArray">If a new item was added to the array, a new is generated and returned here</param>
+        /// <returns>True if a new item was added to the collection</returns>
+        public static bool EnsureArrayItem<T>(this T[] array, T item, out T[] returnArray) where T : IComparable<T>
+        {
+            if (!array.Contains(item))
+            {
+                returnArray = array.AddItem(item);
+                return true;
+            }
+            returnArray = null;
+            return false;
         }
     }
 }

--- a/Runtime/Extensions/CollectionsExtensions.cs
+++ b/Runtime/Extensions/CollectionsExtensions.cs
@@ -125,19 +125,23 @@ namespace RealityCollective.Extensions
             input.Values.CopyTo(output, 0);
             return output;
         }
-       
+
         /// <summary>
         /// Validate if a list contains an item and add it if not found.
         /// </summary>
         /// <typeparam name="T">Data type used in the List.</typeparam>
         /// <param name="list">The instance of the List to validate.</param>
         /// <param name="item">The item of Type T to add to the list if not found</param>
-        public static void EnsureListItem<T>(this IList<T> list, T item)
+        /// <returns>True if a new item was added to the collection</returns>
+        public static bool EnsureListItem<T>(this IList<T> list, T item)
         {
             if (!list.Contains(item))
             {
                 list.Add(item);
+                return true;
             }
+
+            return false;
         }
 
         /// <summary>
@@ -152,18 +156,20 @@ namespace RealityCollective.Extensions
         /// <param name="key">The Key of a <see cref="KeyValuePair{TKey, TValue}"/> to validate against the dictionary with.</param>
         /// <param name="value">The Value of a <see cref="KeyValuePair{TKey, TValue}"/> to set the dictionary item with if required.</param>
         /// <param name="update">By default, the Ensure function will override the existing dictionary value if found, if this is not required it can be overridden with this bool.  Setting this to <see cref="false"/> will leave the dictionary item untouched if found.</param>
-        public static void EnsureDictionaryItem<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value, bool update = true)
+        /// <returns>True if a new item was added to the collection</returns>
+        public static bool EnsureDictionaryItem<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value, bool update = true)
         {
             if(!dictionary.TryGetValue(key, out _))
             {
                 dictionary.Add(key, value);
-                return;
+                return true;
             }
 
             if (update)
             {
                 dictionary[key] = value;
             }
+            return false;
         }
     }
 }

--- a/Runtime/Extensions/ComponentExtensions.cs
+++ b/Runtime/Extensions/ComponentExtensions.cs
@@ -72,13 +72,16 @@ namespace RealityCollective.Extensions
         /// exists on the game object.
         /// </summary>
         /// <param name="gameObject">The <see cref="GameObject"/> to remove the component from.</param>
-        public static void EnsureComponentDestroyed<T>(this GameObject gameObject) where T : Component
+        /// <returns>True if a new item was added to the collection</returns>
+        public static bool EnsureComponentDestroyed<T>(this GameObject gameObject) where T : Component
         {
             T foundComponent = gameObject.GetComponent<T>();
             if (foundComponent.IsNotNull())
             {
                 foundComponent.Destroy();
+                return true;
             }
+            return false;
         }
 
         /// Validates the <see cref="Component"/> reference.
@@ -100,13 +103,16 @@ namespace RealityCollective.Extensions
         /// </summary>
         /// <param name="gameObject">The <see cref="GameObject"/> to remove the component from.</param>
         /// <param name="component">A component on the game object for which a component of type should be removed.</param>
-        public static void EnsureComponentDestroyed(this GameObject gameObject, Type component)
+        /// <returns>True if a new item was added to the collection</returns>
+        public static bool EnsureComponentDestroyed(this GameObject gameObject, Type component)
         {
             var foundComponent = gameObject.GetComponent(component);
             if (foundComponent.IsNotNull())
             {
                 foundComponent.Destroy();
+                return true;
             }
+            return false;
         }
 
         /// Sets the <see cref="GameObject"/> this <see cref="Component"/> is attached to, to the specified state.


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
Updated Ensure Extensions to also return a boolean IF an item was added or actioned upon, where possible
Allows to have logic to react if the collection was updated (or action taken, like destroy)

## Changes
<!-- Brief list of the targeted features that are being changed. -->

* ArrayExtensions - Added new EnsureArray
* CollectionExtensions
* ComponentExtensions

