### PR TITLE
Fix empty GUID resolution

### DIFF
--- a/Runtime/Extensions/TypeExtensions.cs
+++ b/Runtime/Extensions/TypeExtensions.cs
@@ -101,8 +101,12 @@ namespace RealityCollective.Extensions
         {
             resolvedType = null;
 
-            if (guid == Guid.Empty ||
-                !TypeCache.Current.TryGetValue(guid, out resolvedType))
+            if (guid == Guid.Empty)
+            {
+                return false;
+            }
+
+            if (!TypeCache.Current.TryGetValue(guid, out resolvedType))
             {
                 //Serious enough to put severe logging here as it will cause you many hours of hair pulling, only to find it is because Unity removed the class to be helpful with its Code Stripping functionality.
                 //Add a Link.XML to the project and sleep better.


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
Fixes an edge case where the type extensions DO find an empty guid.  Ensures that the empty guid is handled separately from a known guid that cannot be resolved.
