### PR TITLE
Added new extension to destroy all children of a transform.

### DIFF
--- a/Runtime/Extensions/TransformExtensions.cs
+++ b/Runtime/Extensions/TransformExtensions.cs
@@ -470,5 +470,29 @@ namespace RealityCollective.Extensions
             target.localScale = newScale;
             target.localPosition = finalPosition;
         }
+
+        /// <summary>
+        /// Destroy all children of the target Transform/GameObject
+        /// </summary>
+        /// <param name="target">The transform to destroy all children of</param>
+        /// <param name="immediate">Should the removal use the more destroctive 'Immediate' Method?</param>
+        public static void DestroyChildren(this Transform target, bool immediate = false)
+        {
+            if (target.childCount > 0)
+            {
+                foreach (Transform child in target)
+                {
+                    if (immediate)
+                    {
+                        GameObject.DestroyImmediate(child);
+                    }
+                    else
+                    {
+                        GameObject.Destroy(child);
+                    }
+                }
+            }
+
+        }
     }
 }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

New extension to safely clear out the children of a transform.  I'm constantly writing this function in Unity apps, so makes sense to also make it an extension.