### PR TITLE
Fixes to allow working with all files in hidden folders

### DIFF
--- a/Editor/Utilities/GuidRegenerator.cs
+++ b/Editor/Utilities/GuidRegenerator.cs
@@ -61,7 +61,7 @@ namespace RealityCollective.Editor.Utilities
 
             for (int i = 0; i < assetsRootPath.Count; i++)
             {
-                filesPaths.AddRange(UnityFileHelper.GetUnityAssetsAtPath(assetsRootPath[i]));
+                filesPaths.AddRange(UnityFileHelper.GetAllFilesAtPath(assetsRootPath[i]));
             }
 
             // Create dictionary to hold old-to-new GUID map

--- a/Editor/Utilities/UnityFileHelper.cs
+++ b/Editor/Utilities/UnityFileHelper.cs
@@ -51,5 +51,21 @@ namespace RealityCollective.Editor.Utilities
 
             return filesPaths;
         }
+
+        /// <summary>
+        /// Utility to return all recognized files, including meta files within a specific path
+        /// </summary>
+        /// <param name="assetsRootPath">Root folder from which to search from</param>
+        public static List<string> GetAllFilesAtPath(string assetsRootPath)
+        {
+            // Get list of working files
+            var filesPaths = new List<string>();
+
+            assetsRootPath = Path.GetFullPath(assetsRootPath);
+
+            filesPaths.AddRange(Directory.GetFiles(assetsRootPath, "*.*", SearchOption.AllDirectories));
+
+            return filesPaths;
+        }
     }
 }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

Fixes to allow working with all files in hidden folders

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Extended the Unity File helper with an additional option to get all files and not just Unity's own files.

Updated the GuidRegenerator to use all files as it should not be limited when working with a path.
