### PR TITLE
Switched log wrapping to use stringbuilder to reduce log overflow

### DIFF
--- a/Runtime/Logging/StaticLogger.cs
+++ b/Runtime/Logging/StaticLogger.cs
@@ -26,8 +26,8 @@ namespace RealityCollective.Utilities.Logging
         #endregion Events
 
         #region Private Properties
-        private static StringBuilder sb = new();
-        private static StringBuilder lf = new();
+        private static StringBuilder sb = new StringBuilder();
+        private static StringBuilder lf = new StringBuilder();
         private static int logIndex = 0;
         private static FilterLogType currentLogFilter = FilterLogType.All;
         private static bool pauseLog = false;

--- a/Runtime/Logging/StaticLogger.cs
+++ b/Runtime/Logging/StaticLogger.cs
@@ -26,7 +26,8 @@ namespace RealityCollective.Utilities.Logging
         #endregion Events
 
         #region Private Properties
-        private static StringBuilder sb = new StringBuilder();
+        private static StringBuilder sb = new();
+        private static StringBuilder lf = new();
         private static int logIndex = 0;
         private static FilterLogType currentLogFilter = FilterLogType.All;
         private static bool pauseLog = false;
@@ -81,15 +82,19 @@ namespace RealityCollective.Utilities.Logging
             {
                 if (!appLog)
                 {
-                    if (WrapLog) { Console.WriteLine(WrapTemplate); }
-                    Console.WriteLine(message);
-                    if (WrapLog) { Console.WriteLine(WrapTemplate); }
+                    if (WrapLog)
+                    {
+                        lf.Clear();
+                        lf.AppendLine(WrapTemplate);
+                        lf.AppendLine(message);
+                        lf.AppendLine(WrapTemplate);
+                    }
+
+                    Console.WriteLine(WrapLog ? lf.ToString() : message);
 
                     if (DebugMode)
                     {
-                        if (WrapLog) { Debug.LogFormat(logType, includeStackTrace ? LogOption.None : LogOption.NoStacktrace, null, WrapTemplate); }
-                        Debug.LogFormat(logType, includeStackTrace ? LogOption.None : LogOption.NoStacktrace, null, message);
-                        if (WrapLog) { Debug.LogFormat(logType, includeStackTrace ? LogOption.None : LogOption.NoStacktrace, null, WrapTemplate); }
+                        Debug.LogFormat(logType, includeStackTrace ? LogOption.None : LogOption.NoStacktrace, null, WrapLog ? lf.ToString() : message);
                     }
                     return;
                 }


### PR DESCRIPTION
# Reality Collective - Utilities Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
Log wrapping was introducing too many log events, so StringBuilder was introduced to minimise them.