### PR TITLE
Wrapped the Debug.LogFormat call as Unity "Sometimes" throws a wobbler?

### DIFF
--- a/Runtime/Logging/StaticLogger.cs
+++ b/Runtime/Logging/StaticLogger.cs
@@ -94,7 +94,14 @@ namespace RealityCollective.Utilities.Logging
 
                     if (DebugMode)
                     {
-                        Debug.LogFormat(logType, includeStackTrace ? LogOption.None : LogOption.NoStacktrace, null, WrapLog ? lf.ToString() : message);
+                        try
+                        {
+                            Debug.LogFormat(logType, includeStackTrace ? LogOption.None : LogOption.NoStacktrace, null, WrapLog ? lf.ToString() : message);
+                        }
+                        catch (Exception e)
+                        {
+                            Debug.LogError($"Error logging message: {e.Message}-{message}");
+                        }
                     }
                     return;
                 }


### PR DESCRIPTION
# Reality Collective - Utilities Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
Wrapped the Debug.LogFormat call as Unity "Sometimes" throws a wobbler?